### PR TITLE
OpenSSF Scorecard for Token Permissions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,12 +2,13 @@ name: documentation
 
 on: [push, pull_request, workflow_dispatch]
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3


### PR DESCRIPTION
OpenSSF Scorecard for Token Permissions requires maximum top level permission to be read-all (it was write).  Moved contents write into specific step that requires them.